### PR TITLE
Feature/backend chat hendrik

### DIFF
--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -136,6 +136,14 @@ export class ChatController {
 		return this.chatService.demoteAdmin(Number(req.user.id), Number(channelId), Number(userId));
 	}
 
+	// Make someone owner if you are the owner
+	@Post(':channelId/owner/:userId')
+	@UseGuards(RolesGuard)
+	@Roles('owner')
+	async makeOwner(@Param('channelId') channelId: string, @Param('userId') userId: string) {
+		return this.chatService.makeOwner(Number(channelId), Number(userId));
+	}
+
 	// Change channel password
 	@Post(':channelId/password')
 	@UseGuards(RolesGuard)

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -1017,7 +1017,7 @@ export class ChatService {
 			throw new NotFoundException('User not found');
 		}
 
-		// Check if user is not already banned
+		// Check if user is already unbanned
 		const isBanned = await this.prisma.channel.findFirst({
 			where: {
 				id: channelId,
@@ -1030,7 +1030,7 @@ export class ChatService {
 		});
 
 		if (!isBanned) {
-			throw new BadRequestException('User is not banned');
+			throw new BadRequestException('User is not banned from this channel');
 		}
 
 		// Unban the user

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -500,29 +500,21 @@ export class ChatService {
 			where: { channelId: channelId },
 		});
 
-		// if the user is the owner
+		// if the user is the owner and last member of the channel
 		if (channel.ownerId === user.id) {
-			if (channelUsers.length > 1) {
-				// Assign new owner
-				const newOwner = channelUsers.find(u => u.userId !== user.id);
-				await this.prisma.channel.update({
-					where: { id: channelId },
-					data: { ownerId: newOwner.userId },
-				});
-			} else {
-				// If the owner is the last member of the channel, delete it
-				if (channelUsers.length <= 1) {
-					// First, delete the owner channelUser
-					await this.prisma.channelUser.deleteMany({
-						where: {
-							channelId: channelId,
-						},
-					});
-				}
-				await this.prisma.channel.delete({ where: { id: channelId } });
-				return;
-			}
-		}
+			if (channelUsers.length <= 1) {
+        await this.prisma.channelUser.deleteMany({
+          where: {
+            channelId: channelId,
+          },
+        });
+        await this.prisma.channel.delete({ where: { id: channelId } });
+        return;
+      }
+      else { // if the owner is not the last member
+        throw new ForbiddenException('Owner can not leave a channel. Promote someone else to owner first.');
+      }
+    }
 
 		// Remove user from channel
 		await this.prisma.channelUser.delete({
@@ -732,6 +724,52 @@ export class ChatService {
 		});
 	}
 
+  async makeOwner(channelId: number, userId: number) {
+    const channel = await this.prisma.channel.findUnique({
+      where: { id: channelId },
+    });
+
+    if (!channel) {
+      throw new NotFoundException('Channel not found');
+    }
+
+    // check if user is in the channel
+    const channelUser = await this.prisma.channelUser.findUnique({
+      where: {
+        userId_channelId: {
+          channelId: channelId,
+          userId: userId,
+        },
+      },
+    });
+
+    if (!channelUser) {
+      throw new NotFoundException('User is not part of this channel');
+    }
+
+    // Make the channel owned by user
+    await this.prisma.channel.update({
+      where: { id: channelId },
+      data: { ownerId: userId },
+    });
+
+    // Make the user an admin
+    await this.prisma.channelUser.update({
+      where: {
+        userId_channelId: {
+          channelId: channelId,
+          userId: userId,
+        },
+      },
+      data: {
+        isAdmin: true,
+      },
+    });
+
+    // emit an event someone was promoted to owner
+    this.events.emit('user-promoted-to-owner-in-channel', { channelId, userId });
+  }
+
 	// Owner can edit a channel
 	async editChannel(channelId: number, editChannelDto: EditChannelDto): Promise<Channel> {
 		let channelType = editChannelDto.channelType;
@@ -856,6 +894,13 @@ export class ChatService {
 				channelId: channelId,
 			},
 		});
+
+    // Delete all messages associated with the channel
+    await this.prisma.message.deleteMany({
+      where: {
+        channelId: channelId,
+      },
+    });
 
 		await this.prisma.channel.delete({
 			where: {

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -841,22 +841,6 @@ export class ChatService {
 				...(hashedPassword ? { hash: hashedPassword } : {}),
 				...(channelType ? { type: channelType } : {}),
 			},
-      include: {
-        users: {
-          select: {
-            isAdmin: true,
-            isMuted: true,
-            user: {
-              select: {
-                id: true,
-                image: true,
-                nickname: true,
-                status: true,
-              },
-            },
-          },
-        },
-      }
 		});
 
     // emit an event that a channel was edited

--- a/backend/src/chat/gateway/chat/chat.gateway.ts
+++ b/backend/src/chat/gateway/chat/chat.gateway.ts
@@ -26,6 +26,12 @@ export class ChatGateway implements OnGatewayConnection {
 		this.chatService.events.on('channel-created', async newChannel => {
 			const channelId = newChannel.id;
 
+      // delete the hash and twoFASecret fields from the user objects
+      for (const user of newChannel.users) {
+        delete user.hash;
+        delete user.twoFASecret;
+      }
+
       // Send an event only to the users in the DM if it is a DM
       if (newChannel.type == 'DM') {
         const client1: Socket = this.userIdToSocketMap.get(newChannel.users[0].user.id);
@@ -122,6 +128,7 @@ export class ChatGateway implements OnGatewayConnection {
 			const globalChannelId = await this.chatService.getGlobalChannelId();
 			if (!client && channelId == globalChannelId) {
 				delete user.hash;
+        delete user.twoFASecret;
 				this.server.to(`channel-${channelId}`).emit('user-added', {
 					channelId,
 					userId,
@@ -294,7 +301,40 @@ export class ChatGateway implements OnGatewayConnection {
 				userId,
 				message: `User ${userId} has been banned from channel ${channelId}`,
 			});
-		});
+
+      // Remove the user from the channel
+      const client: Socket = this.userIdToSocketMap.get(userId);
+      if (!client) {
+        // if socketId not found, client is not currently connected and doesnt need the websocket event
+        return;
+      }
+
+      client.leave(`channel-${channelId}`);
+      console.log(`User ${userId} left a room: channel-${channelId}`);
+
+      // Update channelIdToUserIds map: remove user from channel
+      const userIdsInChannel = this.channelIdToUserIds.get(channelId);
+      if (userIdsInChannel) {
+        userIdsInChannel.delete(userId);
+
+        // If no more users in the channel, we can also delete the channel entry
+        if (userIdsInChannel.size === 0) {
+          this.channelIdToUserIds.delete(channelId);
+        }
+      }
+
+      client.emit('channel-banned', {
+        channelId,
+        message: `You have been banned and removed from channel ${channelId}`,
+      });
+
+      // Send a message to all users in the channel that a user has been removed
+      client.broadcast.to(`channel-${channelId}`).emit('user-banned', {
+        channelId,
+        userId,
+        message: `User ${userId} has been banned and removed from channel ${channelId}`,
+      });
+    });
 
 		// Listener for a user being unbanned from a channel
 		this.chatService.events.on('user-unbanned-in-channel', async data => {

--- a/backend/src/chat/gateway/chat/chat.gateway.ts
+++ b/backend/src/chat/gateway/chat/chat.gateway.ts
@@ -292,6 +292,27 @@ export class ChatGateway implements OnGatewayConnection {
 			});
 		});
 
+    // Listener for a user being promoted to owner
+    this.chatService.events.on('user-promoted-to-owner-in-channel', async ({ channelId, userId }) => {
+      const client: Socket = this.userIdToSocketMap.get(userId);
+      if (!client) {
+        // if socketId not found, client is not currently connected and doesnt need the websocket event
+        return;
+      }
+
+      client.emit('user-promoted-to-owner', {
+        channelId,
+        message: `You have been promoted to owner in channel ${channelId}`,
+      });
+
+      // Send a message to all users in the channel that a user has been promoted to owner
+      client.broadcast.to(`channel-${channelId}`).emit('user-promoted-to-owner', {
+        channelId,
+        userId,
+        message: `User ${userId} has been promoted to owner in channel ${channelId}`,
+      });
+    });
+
 		// Listener for a user being banned from a channel
 		this.chatService.events.on('user-banned-in-channel', async data => {
 			const { channelId, userId } = data;

--- a/backend/src/chat/roleguard/role.guard.ts
+++ b/backend/src/chat/roleguard/role.guard.ts
@@ -48,7 +48,7 @@ export class RolesGuard implements CanActivate {
 			if (channel.ownerId === Number(userId)) {
 				return true;
 			}
-      throw new UnauthorizedException('You are not the owner of this channel!');
+			throw new UnauthorizedException('You are not the owner of this channel!');
 		}
 
 		// If the user is none of the above

--- a/backend/src/chat/roleguard/role.guard.ts
+++ b/backend/src/chat/roleguard/role.guard.ts
@@ -48,6 +48,7 @@ export class RolesGuard implements CanActivate {
 			if (channel.ownerId === Number(userId)) {
 				return true;
 			}
+      throw new UnauthorizedException('You are not the owner of this channel!');
 		}
 
 		// If the user is none of the above


### PR DESCRIPTION
Number of fixes on backend for chat.

- When a channel is deleted, the associated messages of the channel are now properly deleted first, so you won't see the internal server error anymore
- A banned user is now removed from the websocket, on top of being removed from the channel in the DB.
- There is now a makeOwner post request:
```
    // Make someone owner if you are the owner
    @Post(':channelId/owner/:userId')
    @UseGuards(RolesGuard)
    @Roles('owner')
    async makeOwner(@Param('channelId') channelId: string, @Param('userId') userId: string) {
        return this.chatService.makeOwner(Number(channelId), Number(userId));
    }
```

- When a user wants to leave a channel, they must transfer ownership to someone else first if they are the owner
- I could not reproduce your rebanning error. Probably it is because the user needs to join the channel first again? When you are banned, you are removed from the channel!
- As discussed in the meeting yesterday, I have removed the users from the editChannel Event. User hashes should also be removed now from channel-create
