### PR TITLE
feat: added mute duration to the websocket event for mute

### DIFF
--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -648,7 +648,7 @@ export class ChatService {
 		}, muteDuration * 60 * 1000); // Convert minutes to milliseconds
 
 		// emit event that user was muted
-		this.events.emit('user-muted-in-channel', { channelId, userId });
+		this.events.emit('user-muted-in-channel', { channelId, userId, muteDuration });
 	}
 
 	async unmuteUser(channelId: number, userId: number) {

--- a/backend/src/chat/gateway/chat/chat.gateway.ts
+++ b/backend/src/chat/gateway/chat/chat.gateway.ts
@@ -207,7 +207,7 @@ export class ChatGateway implements OnGatewayConnection {
 			});
 		});
 
-		this.chatService.events.on('user-muted-in-channel', async ({ channelId, userId }) => {
+		this.chatService.events.on('user-muted-in-channel', async ({ channelId, userId, muteDuration }) => {
 			const client: Socket = this.userIdToSocketMap.get(userId);
 			if (!client) {
 				// if socketId not found, client is not currently connected and doesnt need the websocket event
@@ -216,14 +216,16 @@ export class ChatGateway implements OnGatewayConnection {
 
 			client.emit('user-muted', {
 				channelId,
-				message: `You have been muted in channel ${channelId}`,
+        muteDuration,
+				message: `You have been muted in channel ${channelId}, for ${muteDuration} seconds`,
 			});
 
 			// Send a message to all users in the channel that a user has been muted
 			client.broadcast.to(`channel-${channelId}`).emit('user-muted', {
 				channelId,
 				userId,
-				message: `User ${userId} has been muted in channel ${channelId}`,
+        muteDuration,
+				message: `User ${userId} has been muted in channel ${channelId}, for ${muteDuration} seconds`,
 			});
 		});
 

--- a/backend/src/chat/gateway/chat/chat.gateway.ts
+++ b/backend/src/chat/gateway/chat/chat.gateway.ts
@@ -217,7 +217,7 @@ export class ChatGateway implements OnGatewayConnection {
 			client.emit('user-muted', {
 				channelId,
         muteDuration,
-				message: `You have been muted in channel ${channelId}, for ${muteDuration} seconds`,
+				message: `You have been muted in channel ${channelId}, for ${muteDuration} minutes`,
 			});
 
 			// Send a message to all users in the channel that a user has been muted
@@ -225,7 +225,7 @@ export class ChatGateway implements OnGatewayConnection {
 				channelId,
 				userId,
         muteDuration,
-				message: `User ${userId} has been muted in channel ${channelId}, for ${muteDuration} seconds`,
+				message: `User ${userId} has been muted in channel ${channelId}, for ${muteDuration} minutes`,
 			});
 		});
 


### PR DESCRIPTION
Edited websocket event:

[user-muted]
```
{
  "channelId": 2,
  "muteDuration": 1,
  "message": "You have been muted in channel 2, for 1 minutes"
}
```